### PR TITLE
feat: MainViewModel에 fetchPokemonList 로직 구현

### DIFF
--- a/GottaCatch'EmAll.xcodeproj/project.pbxproj
+++ b/GottaCatch'EmAll.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		F2889BE92D240CF1008CAD5C /* RxMoya in Frameworks */ = {isa = PBXBuildFile; productRef = F2889BE82D240CF1008CAD5C /* RxMoya */; };
 		F2889BEC2D240D06008CAD5C /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = F2889BEB2D240D06008CAD5C /* SnapKit */; };
 		F2889C242D241CE2008CAD5C /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = F2889C232D241CE2008CAD5C /* .gitignore */; };
+		F2B7BC602D262ACD001DE837 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = F2B7BC5F2D262ACD001DE837 /* RxCocoa */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -46,6 +47,7 @@
 			files = (
 				F2889BEC2D240D06008CAD5C /* SnapKit in Frameworks */,
 				F2889BE92D240CF1008CAD5C /* RxMoya in Frameworks */,
+				F2B7BC602D262ACD001DE837 /* RxCocoa in Frameworks */,
 				F2889BE72D240CF1008CAD5C /* Moya in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -93,6 +95,7 @@
 				F2889BE62D240CF1008CAD5C /* Moya */,
 				F2889BE82D240CF1008CAD5C /* RxMoya */,
 				F2889BEB2D240D06008CAD5C /* SnapKit */,
+				F2B7BC5F2D262ACD001DE837 /* RxCocoa */,
 			);
 			productName = "GottaCatch'EmAll";
 			productReference = F2889BB92D240249008CAD5C /* GottaCatch'EmAll.app */;
@@ -125,6 +128,7 @@
 			packageReferences = (
 				F2889BE52D240CF1008CAD5C /* XCRemoteSwiftPackageReference "Moya" */,
 				F2889BEA2D240D06008CAD5C /* XCRemoteSwiftPackageReference "SnapKit" */,
+				F2B7BC5E2D262ACD001DE837 /* XCRemoteSwiftPackageReference "RxSwift" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = F2889BBA2D240249008CAD5C /* Products */;
@@ -369,6 +373,14 @@
 				minimumVersion = 5.7.1;
 			};
 		};
+		F2B7BC5E2D262ACD001DE837 /* XCRemoteSwiftPackageReference "RxSwift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ReactiveX/RxSwift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 6.8.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -386,6 +398,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = F2889BEA2D240D06008CAD5C /* XCRemoteSwiftPackageReference "SnapKit" */;
 			productName = SnapKit;
+		};
+		F2B7BC5F2D262ACD001DE837 /* RxCocoa */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F2B7BC5E2D262ACD001DE837 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxCocoa;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/GottaCatch'EmAll/ViewModel/MainViewModel.swift
+++ b/GottaCatch'EmAll/ViewModel/MainViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import RxSwift
+import RxCocoa
 
 class MainViewModel {
     private let networkManager = NetworkManager.shared
@@ -15,7 +16,22 @@ class MainViewModel {
     var pokemonList: BehaviorSubject<[PokemonListItem]> = BehaviorSubject(value: [])
     
     var error: PublishSubject<String> = PublishSubject()
-
+    
     private var limit: Int = 20
     private var offset: Int = 0
+    
+    func fetchPokemonList() {
+        let endpoint = PokemonAPI.fetchPokemonList(limit: limit, offset: offset)
+        
+        networkManager.fetch(endpoint: endpoint, type: PokemonList.self)
+            .subscribe{ [weak self] result in
+                switch result {
+                case .success(let pokemonListData):
+                    self?.pokemonList.onNext(pokemonListData.results)
+                case .failure(let error):
+                    self?.error.onNext(error.localizedDescription)
+                }
+            }
+            .disposed(by: disposeBag)
+    }
 }


### PR DESCRIPTION
### 📝 작업 내용
  - ViewModel(MainViewModel) 구현 및 fetchPokemonList 메서드 작성
  - BehaviorSubject로 포켓몬 리스트 관리
  - PublishSubject로 에러 메시지 전달
  - NetworkManager 활용하여 API 데이터 요청

### 🚀 주요 변경 사항
- MainViewModel에서 limit=20, offset=0으로 API 호출
- RxSwift를 활용한 데이터 바인딩 준비
- NetworkManager와 PokemonAPI 연결

### 📷 스크린샷
<img width="400" alt="" src="" />


### 💡 추가 논의 사항
  - MainViewController와의 데이터 바인딩 최적화 필요
  - 에러 처리 로직 및 로딩 상태 UI 추가 필요

