### PR TITLE
feat: pokemon list infinite scroll 구현

### DIFF
--- a/GottaCatch'EmAll.xcodeproj/project.pbxproj
+++ b/GottaCatch'EmAll.xcodeproj/project.pbxproj
@@ -15,8 +15,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		F20F0C7E2D2B116C0047CF1B /* GottaCatch'EmAll.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "GottaCatch'EmAll.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F2889C232D241CE2008CAD5C /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
-		F2B7BD852D2847CB001DE837 /* GottaCatch'EmAll.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = "GottaCatch'EmAll.app"; path = "/Users/eden/Desktop/iOS/GottaCatch'EmAll/build/Debug-iphoneos/GottaCatch'EmAll.app"; sourceTree = "<absolute>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -60,6 +60,7 @@
 			children = (
 				F2889C232D241CE2008CAD5C /* .gitignore */,
 				F2B7BD332D2638D5001DE837 /* GottaCatch'EmAll */,
+				F20F0C7E2D2B116C0047CF1B /* GottaCatch'EmAll.app */,
 			);
 			sourceTree = "<group>";
 		};
@@ -89,7 +90,7 @@
 				F2B7BC5F2D262ACD001DE837 /* RxCocoa */,
 			);
 			productName = "GottaCatch'EmAll";
-			productReference = F2B7BD852D2847CB001DE837 /* GottaCatch'EmAll.app */;
+			productReference = F20F0C7E2D2B116C0047CF1B /* GottaCatch'EmAll.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */

--- a/GottaCatch'EmAll/View/Main/PokemonCell.swift
+++ b/GottaCatch'EmAll/View/Main/PokemonCell.swift
@@ -20,6 +20,8 @@ final class PokemonCell: UICollectionViewCell {
         return imageView
     }()
     
+    private let disposeBag = DisposeBag()
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupUI()
@@ -33,6 +35,7 @@ final class PokemonCell: UICollectionViewCell {
         contentView.addSubview(pokemonImageView)
         contentView.backgroundColor = .cellBackground
         contentView.layer.cornerRadius = 8
+        contentView.clipsToBounds = true
         
         pokemonImageView.snp.makeConstraints { make in
             make.edges.equalToSuperview().inset(8)
@@ -40,5 +43,14 @@ final class PokemonCell: UICollectionViewCell {
     }
     
     func configure(id: Int) {
+        let networkManager = NetworkManager.shared
+        networkManager.fetchImage(for: id)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] image in
+                self?.pokemonImageView.image = image
+            }, onFailure: { error in
+                print(" \(id): \(error.localizedDescription)")
+            })
+            .disposed(by: disposeBag)
     }
 }

--- a/GottaCatch'EmAll/View/Main/PokemonCell.swift
+++ b/GottaCatch'EmAll/View/Main/PokemonCell.swift
@@ -20,8 +20,6 @@ final class PokemonCell: UICollectionViewCell {
         return imageView
     }()
     
-    private let disposeBag = DisposeBag()
-    
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupUI()
@@ -42,14 +40,5 @@ final class PokemonCell: UICollectionViewCell {
     }
     
     func configure(id: Int) {
-        let networkManager = NetworkManager.shared
-        networkManager.fetchImage(for: id)
-            .observe(on: MainScheduler.instance)
-            .subscribe(onSuccess: { [weak self] image in
-                self?.pokemonImageView.image = image
-            }, onFailure: { error in
-                print(" \(id): \(error.localizedDescription)")
-            })
-            .disposed(by: disposeBag)
     }
 }

--- a/GottaCatch'EmAll/View/Main/PokemonCell.swift
+++ b/GottaCatch'EmAll/View/Main/PokemonCell.swift
@@ -20,7 +20,8 @@ final class PokemonCell: UICollectionViewCell {
         return imageView
     }()
     
-    private let disposeBag = DisposeBag()
+    private var disposeBag = DisposeBag()
+    private var currentPokemonId: Int?
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -29,6 +30,13 @@ final class PokemonCell: UICollectionViewCell {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        pokemonImageView.image = nil
+        disposeBag = DisposeBag()
+        currentPokemonId = nil
     }
     
     private func setupUI() {
@@ -43,13 +51,17 @@ final class PokemonCell: UICollectionViewCell {
     }
     
     func configure(id: Int) {
+        guard currentPokemonId != id else { return }
+        currentPokemonId = id
+        
         let networkManager = NetworkManager.shared
         networkManager.fetchImage(for: id)
             .observe(on: MainScheduler.instance)
             .subscribe(onSuccess: { [weak self] image in
+                guard self?.currentPokemonId == id else { return }
                 self?.pokemonImageView.image = image
             }, onFailure: { error in
-                print(" \(id): \(error.localizedDescription)")
+                print("Failed to load Pokemon \(id): \(error.localizedDescription)")
             })
             .disposed(by: disposeBag)
     }

--- a/GottaCatch'EmAll/ViewModel/MainViewModel.swift
+++ b/GottaCatch'EmAll/ViewModel/MainViewModel.swift
@@ -13,25 +13,39 @@ class MainViewModel {
     private let networkManager = NetworkManager.shared
     private let disposeBag = DisposeBag()
     
-    var pokemonList: BehaviorSubject<[PokemonListItem]> = BehaviorSubject(value: [])
-    
+    var pokemonList: BehaviorRelay<[PokemonListItem]> = BehaviorRelay(value: [])
     var error: PublishSubject<String> = PublishSubject()
     
     private var limit: Int = 20
     private var offset: Int = 0
+    private var isFetching: Bool = false
+    private var totalPokemonCount: Int = Int.max
     
     func fetchPokemonList() {
-        let endpoint = PokemonAPI.fetchPokemonList(limit: limit, offset: offset)
+        guard !isFetching, offset < totalPokemonCount else { return }
+        isFetching = true
         
+        let endpoint = PokemonAPI.fetchPokemonList(limit: limit, offset: offset)
         networkManager.fetch(endpoint: endpoint, type: PokemonList.self)
-            .subscribe{ [weak self] result in
+            .subscribe { [weak self] result in
+                guard let self = self else { return }
+                self.isFetching = false
+                
                 switch result {
                 case .success(let pokemonListData):
-                    self?.pokemonList.onNext(pokemonListData.results)
+                    self.totalPokemonCount = pokemonListData.count
+                    self.offset += self.limit
+                    
+                    let currentList = self.pokemonList.value
+                    let updatedList = currentList + pokemonListData.results
+                    self.pokemonList.accept(updatedList)
+                    
                 case .failure(let error):
-                    self?.error.onNext(error.localizedDescription)
+                    self.error.onNext(error.localizedDescription)
                 }
             }
             .disposed(by: disposeBag)
     }
+
 }
+


### PR DESCRIPTION
### 📝 작업 내용

- 불필요한 UIKit Delegate/DataSource 코드 제거 및 RxSwift 바인딩으로 전환
- offset 기반 무한 스크롤 기능 구현
- 셀 재사용 시 이미지 깜빡임 현상 수정

### 🚀 주요 변경 사항

- **코드 개선**
    - MainViewController에서 불필요한 UICollectionViewDelegate, DataSource 프로토콜 제거
    - RxSwift를 활용한 데이터 바인딩으로 전환
    - 미사용 변수 및 import 구문 정리
- **무한 스크롤 구현**
    - 페이지네이션 구현
    - 스크롤 감지를 통한 자동 데이터 로드
    - 중복 요청 방지 로직 추가
    - isFetching 플래그를 통한 로딩 상태 관리
- **셀 재사용 이슈 수정**
    - PokemonCell에 currentPokemonId 프로퍼티 추가
    - prepareForReuse 메서드에서 이미지 및 구독 초기화
    - disposeBag 재생성을 통한 이전 구독 취소
    - 이미지 설정 시 ID 검증 로직 추가

### 📷 스크린샷

<img width="400" alt="무한 스크롤 및 이미지 로딩 데모" src="https://github.com/user-attachments/assets/1ae4b09a-38e0-4efb-8503-1621cd96d27e" />

### 💡 추가 논의 사항

- Observable, Subject, Relay의 차이점과 적절한 사용 케이스에 대한 학습 필요
- Kingfisher 라이브러리 도입 검토